### PR TITLE
Use Constexpr

### DIFF
--- a/c++/NuFast.cpp
+++ b/c++/NuFast.cpp
@@ -2,8 +2,8 @@
 #include <stdio.h>
 
 // Some constants
-double const eVsqkm_to_GeV_over4 = 1e-9 / 1.97327e-7 * 1e3 / 4;
-double const YerhoE2a = 1.52588e-4;
+constexpr double const eVsqkm_to_GeV_over4 = 1e-9 / 1.97327e-7 * 1e3 / 4;
+constexpr double const YerhoE2a = 1.52588e-4;
 
 // Probability_Matter_LBL calculates all nine oscillation probabilities including
 // the matter effect in an optimized, fast, and efficient way. The precision can


### PR DESCRIPTION
Constexpr explicilty tells compiler to evaluate during compile time reducing overhead during run time and potentially resulting in faster code.

Compiler should be smart enough to figure out that eVsqkm_to_GeV_over4  and YerhoE2a could be evaluated at compile time.
But rather than hoping that compiler is smart it is better to help and be explcit